### PR TITLE
Return the listener so that it can be detached later

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,7 @@ Hook an event handler for the mouse wheel on `element`.
     + `dx, dy, dz` is the amount of scrolling vertically, horizontally and depth-wise in pixels
 * `noScroll` is an optional flag, which if set disables scrolling the page
 
+Returns listener function `listener` so that it may be detached later with `element.removeEventListener('wheel', listener)`
+
 # License
 (c) 2015 Mikola Lysenko. MIT License

--- a/wheel.js
+++ b/wheel.js
@@ -11,7 +11,7 @@ function mouseWheelListen(element, callback, noScroll) {
     element = window
   }
   var lineHeight = toPX('ex', element)
-  element.addEventListener('wheel', function(ev) {
+  var listener = function(ev) {
     if(noScroll) {
       ev.preventDefault()
     }
@@ -34,5 +34,7 @@ function mouseWheelListen(element, callback, noScroll) {
     if(dx || dy || dz) {
       return callback(dx, dy, dz)
     }
-  })
+  }
+  element.addEventListener('wheel', listener)
+  return listener
 }


### PR DESCRIPTION
Just a small tweak. This PR returns the listener instead of undefined so that it may be detached later. It also documents how you'd do this.
