### PR TITLE
Include MouseEvent as callback parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ npm i mouse-wheel
 Hook an event handler for the mouse wheel on `element`.
 
 * `element` is an optional DOM element, or if unspecified then is the window object.
-* `callback(dx, dy, dz)` is called whenever the mouse scrolls
+* `callback(dx, dy, dz, ev)` is called whenever the mouse scrolls
     + `dx, dy, dz` is the amount of scrolling vertically, horizontally and depth-wise in pixels
+    + `ev` is the MouseEvent object associated with the event
 * `noScroll` is an optional flag, which if set disables scrolling the page
 
 Returns listener function `listener` so that it may be detached later with `element.removeEventListener('wheel', listener)`

--- a/wheel.js
+++ b/wheel.js
@@ -32,7 +32,7 @@ function mouseWheelListen(element, callback, noScroll) {
     dy *= scale
     dz *= scale
     if(dx || dy || dz) {
-      return callback(dx, dy, dz)
+      return callback(dx, dy, dz, ev)
     }
   }
   element.addEventListener('wheel', listener)


### PR DESCRIPTION
For e.g. if you need to check if the meta key is currently down, or if you need to stop propagation, or if you need the clientX/clientY associated with the event.

:smile:
