### PR TITLE
Make wheel events passive.

### DIFF
--- a/wheel.js
+++ b/wheel.js
@@ -35,6 +35,6 @@ function mouseWheelListen(element, callback, noScroll) {
       return callback(dx, dy, dz, ev)
     }
   }
-  element.addEventListener('wheel', listener)
+  element.addEventListener('wheel', listener, {passive: true)
   return listener
 }


### PR DESCRIPTION
I observed a bunch of warnings due to the new [passive event API](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md), and this change fixes those warnings. Could add feature detection here too, but I'm not sure how critical this is given the distribution of this feature (in Chrome 51, Firefox 49).